### PR TITLE
Remove DrawText in gwater2_emitter from Resolved Depth Buffer

### DIFF
--- a/lua/entities/gwater2_drain.lua
+++ b/lua/entities/gwater2_drain.lua
@@ -72,7 +72,7 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) != 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) != 0)
 	if is_depth_pass then return end
 	local pos, ang = self:GetPos(), self:GetAngles()
 	ang:RotateAroundAxis(ang:Right(), 180)

--- a/lua/entities/gwater2_drain.lua
+++ b/lua/entities/gwater2_drain.lua
@@ -69,8 +69,11 @@ function ENT:SpawnFunction(ply, tr, class)
 	return ent
 end
 
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if isDepthPass then return end
 	local pos, ang = self:GetPos(), self:GetAngles()
 	ang:RotateAroundAxis(ang:Right(), 180)
 	pos = pos + ang:Up()*0.25

--- a/lua/entities/gwater2_drain.lua
+++ b/lua/entities/gwater2_drain.lua
@@ -72,8 +72,8 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
-	if isDepthPass then return end
+	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if is_depth_pass then return end
 	local pos, ang = self:GetPos(), self:GetAngles()
 	ang:RotateAroundAxis(ang:Right(), 180)
 	pos = pos + ang:Up()*0.25

--- a/lua/entities/gwater2_emitter.lua
+++ b/lua/entities/gwater2_emitter.lua
@@ -107,8 +107,11 @@ function ENT:SetupDataTables()
 	end)
 end
 
-function ENT:Draw()
+function ENT:Draw(flags)
 	self:DrawModel()
+
+	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if isDepthPass then return end
 
 	local pos, ang = self:GetPos(), self:GetAngles()
 	ang:RotateAroundAxis(ang:Up(), 180)

--- a/lua/entities/gwater2_emitter.lua
+++ b/lua/entities/gwater2_emitter.lua
@@ -110,8 +110,8 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
-	if isDepthPass then return end
+	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if is_depth_pass then return end
 
 	local pos, ang = self:GetPos(), self:GetAngles()
 	ang:RotateAroundAxis(ang:Up(), 180)

--- a/lua/entities/gwater2_emitter.lua
+++ b/lua/entities/gwater2_emitter.lua
@@ -108,7 +108,7 @@ function ENT:SetupDataTables()
 end
 
 function ENT:Draw(flags)
-	self:DrawModel()
+	self:DrawModel(flags)
 
 	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
 	if isDepthPass then return end

--- a/lua/entities/gwater2_emitter.lua
+++ b/lua/entities/gwater2_emitter.lua
@@ -110,7 +110,7 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) != 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) != 0)
 	if is_depth_pass then return end
 
 	local pos, ang = self:GetPos(), self:GetAngles()

--- a/lua/entities/gwater2_forcefield.lua
+++ b/lua/entities/gwater2_forcefield.lua
@@ -22,8 +22,8 @@ end
 
 if CLIENT then
 	function ENT:Draw(flags)
-		local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
-		if isDepthPass then return end
+		local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+		if is_depth_pass then return end
 		
 		-- tried a merge effect between colors but I think its too much
 		--local str = (self:GetStrength() + 200) / 2 / 200	-- (0 - 1)

--- a/lua/entities/gwater2_forcefield.lua
+++ b/lua/entities/gwater2_forcefield.lua
@@ -21,7 +21,10 @@ function ENT:Initialize()
 end
 
 if CLIENT then
-	function ENT:Draw()
+	function ENT:Draw(flags)
+		local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+		if isDepthPass then return end
+		
 		-- tried a merge effect between colors but I think its too much
 		--local str = (self:GetStrength() + 200) / 2 / 200	-- (0 - 1)
 		--local red   = math.Clamp(1 - (str + 0.5)^10 + 0.5, 0, 1)

--- a/lua/entities/gwater2_forcefield.lua
+++ b/lua/entities/gwater2_forcefield.lua
@@ -22,7 +22,7 @@ end
 
 if CLIENT then
 	function ENT:Draw(flags)
-		local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+		local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) != 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) != 0)
 		if is_depth_pass then return end
 		
 		-- tried a merge effect between colors but I think its too much

--- a/lua/entities/gwater2_transporter_recv.lua
+++ b/lua/entities/gwater2_transporter_recv.lua
@@ -121,8 +121,8 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
-	if isDepthPass then return end
+	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if is_depth_pass then return end
 
 	self.link = self.link or IsValid(self:GetNWEntity("GWATER2_Link")) and self:GetNWEntity("GWATER2_Link")
 

--- a/lua/entities/gwater2_transporter_recv.lua
+++ b/lua/entities/gwater2_transporter_recv.lua
@@ -121,7 +121,7 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) != 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) != 0)
 	if is_depth_pass then return end
 
 	self.link = self.link or IsValid(self:GetNWEntity("GWATER2_Link")) and self:GetNWEntity("GWATER2_Link")

--- a/lua/entities/gwater2_transporter_recv.lua
+++ b/lua/entities/gwater2_transporter_recv.lua
@@ -118,8 +118,11 @@ function ENT:Use(_, _, type)
 	self:SetOn(not self:GetOn())
 end
 
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if isDepthPass then return end
 
 	self.link = self.link or IsValid(self:GetNWEntity("GWATER2_Link")) and self:GetNWEntity("GWATER2_Link")
 

--- a/lua/entities/gwater2_transporter_send.lua
+++ b/lua/entities/gwater2_transporter_send.lua
@@ -59,8 +59,11 @@ function ENT:TriggerInput(name, val)
 	end
 end
 
-function ENT:Draw()
-	self:DrawModel()
+function ENT:Draw(flags)
+	self:DrawModel(flags)
+
+	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if isDepthPass then return end
 
 	self.link = self.link or IsValid(self:GetNWEntity("GWATER2_Link")) and self:GetNWEntity("GWATER2_Link")
 

--- a/lua/entities/gwater2_transporter_send.lua
+++ b/lua/entities/gwater2_transporter_send.lua
@@ -62,7 +62,7 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	local is_depth_pass = (bit.band(flags, STUDIO_SSAODEPTHTEXTURE) != 0 or bit.band(flags, STUDIO_SHADOWDEPTHTEXTURE) != 0)
 	if is_depth_pass then return end
 
 	self.link = self.link or IsValid(self:GetNWEntity("GWATER2_Link")) and self:GetNWEntity("GWATER2_Link")

--- a/lua/entities/gwater2_transporter_send.lua
+++ b/lua/entities/gwater2_transporter_send.lua
@@ -62,8 +62,8 @@ end
 function ENT:Draw(flags)
 	self:DrawModel(flags)
 
-	local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
-	if isDepthPass then return end
+	local is_depth_pass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 or bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+	if is_depth_pass then return end
 
 	self.link = self.link or IsValid(self:GetNWEntity("GWATER2_Link")) and self:GetNWEntity("GWATER2_Link")
 


### PR DESCRIPTION
This pull requests fix issue from video. `gwater2_emitter` entity writes .RGB colors to Resolved Depth buffer.

https://github.com/user-attachments/assets/c0d76047-2c75-468c-b964-2d1628474750

